### PR TITLE
Swap default search from "beach" to "sunset" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
-# Snap Shot [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=See%20this%20react%20example&url=https://yog9.github.io/SnapShot/&hashtags=react,context-api,freecodecamp,developers)
-
-[![Build Status](https://travis-ci.org/Yog9/SnapShot.svg?branch=master)](https://travis-ci.org/Yog9/SnapShot)
+# Snap Shot 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![HitCount](http://hits.dwyl.com/Yog9/SnapShot.svg)](http://hits.dwyl.com/Yog9/SnapShot)
 
-[Demo of Snap Shot](https://yog9.github.io/SnapShot/)
+[Demo of Snap Shot](https://honeycombio.github.io/SnapShot/)
 
 ![](/snapscout.png)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Snap Shot 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[Demo of Snap Shot](https://honeycombio.github.io/SnapShot/)
+[Demo of Snap Shot](https://yog9.github.io/SnapShot/)
 
 ![](/snapscout.png)
 

--- a/public/index.html
+++ b/public/index.html
@@ -18,6 +18,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <span class="forkongithub"><a href="https://github.com/Yog9/SnapShot">Fork me on GitHub</a></span>
+    <span class="forkongithub"><a href="https://github.com/honeycombio/SnapShot">Fork me on GitHub</a></span>
   </body>
 </html>

--- a/src/App.js
+++ b/src/App.js
@@ -57,7 +57,7 @@ class App extends Component {
                 path="/mountain"
                 render={() => <Item searchTerm="mountain" />}
               />
-              <Route path="/beach" render={() => <Item searchTerm="beach" />} />
+              <Route path="/sunset" render={() => <Item searchTerm="sunset" />} />
               <Route path="/bird" render={() => <Item searchTerm="bird" />} />
               <Route path="/food" render={() => <Item searchTerm="food" />} />
               <Route

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -6,7 +6,7 @@ const Navigation = () => {
     <nav className="main-nav">
       <ul>
         <li><NavLink to="/mountain">Mountain</NavLink></li>
-        <li><NavLink to="/beach">Beaches</NavLink></li>
+        <li><NavLink to="/sunset">Sunset</NavLink></li>
         <li><NavLink to="/bird">Birds</NavLink></li>
         <li><NavLink to="/food">Food</NavLink></li>
       </ul>


### PR DESCRIPTION
## Which problem is this PR solving?

We're using flickr's public API and thus the content returned from any search is entirely user-generated, and it's not even our users. 

We have observed cases where the `beach` search may return NSFW photos.

Obviously anyone could just type in any search they like and see what flickr has to offer but this change will at least reduce the likelihood that the pre-saved searches return surprising content. 

## Short description of the changes

Change all of the mentions of beach to sunset
Also change mentions of yog9 (original owners of the repo we forked from) to honeycombio
